### PR TITLE
Coreos hyperkube v1.2.6 updates

### DIFF
--- a/coreos/Dockerfile
+++ b/coreos/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:jessie
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get -yy -q \
+    install \
+    iptables \
+    ethtool \
+    ca-certificates \
+    file \
+    util-linux \
+    socat \
+    curl \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN cp /usr/bin/nsenter /nsenter
+
+COPY hyperkube /hyperkube
+RUN chmod a+rx /hyperkube
+
+RUN ln -s /hyperkube /kubelet

--- a/coreos/Dockerfile
+++ b/coreos/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     util-linux \
     socat \
     curl \
+    git \
     nfs-common \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \

--- a/coreos/Dockerfile
+++ b/coreos/Dockerfile
@@ -22,3 +22,7 @@ COPY hyperkube /hyperkube
 RUN chmod a+rx /hyperkube
 
 RUN ln -s /hyperkube /kubelet
+RUN mkdir -p /opt/cni/bin
+RUN curl -L https://github.com/appc/cni/releases/download/v0.2.0/cni-v0.2.0.tgz | tar zxv -C /opt/cni/bin
+ADD https://github.com/projectcalico/calico-cni/releases/download/v1.3.0/calico /opt/cni/bin
+RUN chmod +x /opt/cni/bin/*

--- a/coreos/Dockerfile
+++ b/coreos/Dockerfile
@@ -10,6 +10,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     util-linux \
     socat \
     curl \
+    nfs-common \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
     && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/coreos/Makefile
+++ b/coreos/Makefile
@@ -1,0 +1,27 @@
+KUBERNETES_VERSION = $(shell ./kubernetes-version.sh)
+
+# Convert + to - for docker tag compatibility
+IMAGE_VERSION = $(subst +,_,$(KUBERNETES_VERSION))
+
+TAG = quay.io/coreos/hyperkube:$(IMAGE_VERSION)
+HYPERKUBE = ../_output/dockerized/bin/linux/amd64/hyperkube
+
+.PHONY: all container push clean
+
+all: container
+
+container: Dockerfile $(HYPERKUBE)
+	$(eval TEMPDIR := $(shell mktemp -d -t $(KUBERNETES_VERSION).XXXX))
+	cp $^ $(TEMPDIR)
+	docker build -t $(TAG) $(TEMPDIR)
+	rm -rf $(TEMPDIR)
+
+push:
+	docker push $(TAG)
+
+$(HYPERKUBE):
+	make -C .. release
+
+clean:
+	make -C .. clean
+

--- a/coreos/README.md
+++ b/coreos/README.md
@@ -1,0 +1,19 @@
+# Development
+
+```
+make clean
+make container TAG=quay.io/foo/bar:v0.0.0
+make push TAG=quay.io/foo/bar:v0.0.0
+```
+
+# Release
+
+1. Tag version (e.g. `v1.1.x+coreos.0`)
+1. Create pull-request & merge
+1. Build & push image
+
+    ```
+    make clean
+    make container
+    make push
+    ```

--- a/coreos/kubernetes-version.sh
+++ b/coreos/kubernetes-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source ${KUBE_ROOT}/hack/lib/version.sh
+kube::version::get_version_vars
+echo "${KUBE_GIT_VERSION}"


### PR DESCRIPTION
Carry patches from coreos-v1.2.4 release into v1.2.6.

Also adding CNI binaries into the mainline image, not carrying separate images anymore in the 1.3 releases. Can do the same here.

/cc @colhom 
