### PR TITLE
bump CNI binaries to post v0.3.0 release

### DIFF
--- a/cluster/gce/coreos/master-docker.yaml
+++ b/cluster/gce/coreos/master-docker.yaml
@@ -35,7 +35,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=yes
         ExecStartPre=/usr/bin/mkdir -p /opt/cni
-        ExecStartPre=/usr/bin/curl --fail --silent --show-error --location --create-dirs --output /opt/downloads/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-c864f0e1ea73719b8f4582402b0847064f9883b0.tar.gz
+        ExecStartPre=/usr/bin/curl --fail --silent --show-error --location --create-dirs --output /opt/downloads/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-8a936732094c0941e1543ef5d292a1f4fffa1ac5.tar.gz
         ExecStart=/usr/bin/tar xf /opt/downloads/cni.tar.gz -C /opt/cni/        
         
     - name: kubernetes-download-salt.service

--- a/cluster/gce/coreos/master-rkt.yaml
+++ b/cluster/gce/coreos/master-rkt.yaml
@@ -35,7 +35,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=yes
         ExecStartPre=/usr/bin/mkdir -p /opt/cni
-        ExecStartPre=/usr/bin/curl --fail --silent --show-error --location --create-dirs --output /opt/downloads/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-c864f0e1ea73719b8f4582402b0847064f9883b0.tar.gz
+        ExecStartPre=/usr/bin/curl --fail --silent --show-error --location --create-dirs --output /opt/downloads/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-8a936732094c0941e1543ef5d292a1f4fffa1ac5.tar.gz
         ExecStart=/usr/bin/tar xf /opt/downloads/cni.tar.gz -C /opt/cni/
 
     - name: kubernetes-install-docker2aci.service

--- a/cluster/gce/coreos/node-docker.yaml
+++ b/cluster/gce/coreos/node-docker.yaml
@@ -35,7 +35,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=yes
         ExecStartPre=/usr/bin/mkdir -p /opt/cni
-        ExecStartPre=/usr/bin/curl --fail --silent --show-error --location --create-dirs --output /opt/downloads/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-c864f0e1ea73719b8f4582402b0847064f9883b0.tar.gz
+        ExecStartPre=/usr/bin/curl --fail --silent --show-error --location --create-dirs --output /opt/downloads/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-8a936732094c0941e1543ef5d292a1f4fffa1ac5.tar.gz
         ExecStart=/usr/bin/tar xf /opt/downloads/cni.tar.gz -C /opt/cni/        
 
     - name: kubernetes-download-manifests.service

--- a/cluster/gce/coreos/node-rkt.yaml
+++ b/cluster/gce/coreos/node-rkt.yaml
@@ -35,7 +35,7 @@ coreos:
         Type=oneshot
         RemainAfterExit=yes
         ExecStartPre=/usr/bin/mkdir -p /opt/cni
-        ExecStartPre=/usr/bin/curl --fail --silent --show-error --location --create-dirs --output /opt/downloads/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-c864f0e1ea73719b8f4582402b0847064f9883b0.tar.gz
+        ExecStartPre=/usr/bin/curl --fail --silent --show-error --location --create-dirs --output /opt/downloads/cni.tar.gz https://storage.googleapis.com/kubernetes-release/network-plugins/cni-8a936732094c0941e1543ef5d292a1f4fffa1ac5.tar.gz
         ExecStart=/usr/bin/tar xf /opt/downloads/cni.tar.gz -C /opt/cni/        
 
     - name: kubernetes-install-rkt.service

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -149,7 +149,7 @@ function install-kube-binary-config {
   if [[ "${NETWORK_PROVIDER:-}" == "kubenet" ]] || \
      [[ "${NETWORK_PROVIDER:-}" == "cni" ]]; then
     #TODO(andyzheng0831): We should make the cni version number as a k8s env variable.
-    local -r cni_tar="cni-26b61728ac940c3faf827927782326e921be17b0.tar.gz"
+    local -r cni_tar="cni-8a936732094c0941e1543ef5d292a1f4fffa1ac5.tar.gz"
     download-or-bust "" "https://storage.googleapis.com/kubernetes-release/network-plugins/${cni_tar}"
     tar xzf "${KUBE_HOME}/${cni_tar}" -C "${kube_bin}" --overwrite
     mv "${kube_bin}/bin"/* "${kube_bin}"

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -20,7 +20,7 @@
 REGISTRY?=gcr.io/google_containers
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-CNI_RELEASE=c864f0e1ea73719b8f4582402b0847064f9883b0
+CNI_RELEASE=8a936732094c0941e1543ef5d292a1f4fffa1ac5
 
 UNAME_S:=$(shell uname -s)
 ifeq ($(UNAME_S),Darwin)

--- a/cluster/saltbase/salt/cni/init.sls
+++ b/cluster/saltbase/salt/cni/init.sls
@@ -19,9 +19,9 @@ cni-tar:
     - user: root
     - name: /opt/cni
     - makedirs: True
-    - source: https://storage.googleapis.com/kubernetes-release/network-plugins/cni-c864f0e1ea73719b8f4582402b0847064f9883b0.tar.gz
+    - source: https://storage.googleapis.com/kubernetes-release/network-plugins/cni-8a936732094c0941e1543ef5d292a1f4fffa1ac5.tar.gz
     - tar_options: v
-    - source_hash: md5=5f71ea8046930357e0ca83088064db93
+    - source_hash: md5=ae7ec24d2ffc0fd14a15f527744ba2c3
     - archive_format: tar
     - if_missing: /opt/cni/bin
 


### PR DESCRIPTION
redo of previous PR: https://github.com/coreos/kubernetes/pull/53

This will be needed for rktnetes. cc @aaron @steveeJ 
