### PR TITLE
rkt pods need lo interface

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -50,7 +50,7 @@ type cniNetworkPlugin struct {
 type cniNetwork struct {
 	name          string
 	NetworkConfig *libcni.NetworkConfig
-	CNIConfig     *libcni.CNIConfig
+	CNIConfig     libcni.CNI
 }
 
 func probeNetworkPluginsWithVendorCNIDirPrefix(pluginDir, vendorCNIDirPrefix string) []network.NetworkPlugin {
@@ -61,6 +61,7 @@ func probeNetworkPluginsWithVendorCNIDirPrefix(pluginDir, vendorCNIDirPrefix str
 	}
 	return append(configList, &cniNetworkPlugin{
 		defaultNetwork:     network,
+		loNetwork:          getLoNetwork(vendorCNIDirPrefix),
 		vendorCNIDirPrefix: vendorCNIDirPrefix,
 		execer:             utilexec.New(),
 	})
@@ -104,28 +105,34 @@ func vendorCNIDir(prefix, pluginType string) string {
 	return fmt.Sprintf(VendorCNIDirTemplate, prefix, pluginType)
 }
 
-func (plugin *cniNetworkPlugin) Init(host network.Host, hairpinMode componentconfig.HairpinMode, nonMasqueradeCIDR string) error {
-	var err error
-	plugin.nsenterPath, err = plugin.execer.LookPath("nsenter")
-	if err != nil {
-		return err
-	}
-
+func getLoNetwork(vendorDirPrefix string) *cniNetwork {
 	loConfig, err := libcni.ConfFromBytes([]byte(`{
   "cniVersion": "0.1.0",
   "name": "cni-loopback",
   "type": "loopback"
 }`))
 	if err != nil {
-		return err
+		// The hardcoded config above should always be valid and unit tests will
+		// catch this
+		panic(err)
 	}
 	cninet := &libcni.CNIConfig{
-		Path: []string{DefaultCNIDir, vendorCNIDir(plugin.vendorCNIDirPrefix, loConfig.Network.Type)},
+		Path: []string{vendorCNIDir(vendorDirPrefix, loConfig.Network.Type), DefaultCNIDir},
 	}
-	plugin.loNetwork = &cniNetwork{
+	loNetwork := &cniNetwork{
 		name:          "lo",
 		NetworkConfig: loConfig,
 		CNIConfig:     cninet,
+	}
+
+	return loNetwork
+}
+
+func (plugin *cniNetworkPlugin) Init(host network.Host, hairpinMode componentconfig.HairpinMode, nonMasqueradeCIDR string) error {
+	var err error
+	plugin.nsenterPath, err = plugin.execer.LookPath("nsenter")
+	if err != nil {
+		return err
 	}
 
 	plugin.host = host
@@ -190,7 +197,7 @@ func (network *cniNetwork) addToNetwork(podName string, podNamespace string, pod
 	}
 
 	netconf, cninet := network.NetworkConfig, network.CNIConfig
-	glog.V(4).Infof("About to run with conf.Network.Type=%v, c.Path=%v", netconf.Network.Type, cninet.Path)
+	glog.V(4).Infof("About to run with conf.Network.Type=%v", netconf.Network.Type)
 	res, err := cninet.AddNetwork(netconf, rt)
 	if err != nil {
 		glog.Errorf("Error adding network: %v", err)
@@ -208,7 +215,7 @@ func (network *cniNetwork) deleteFromNetwork(podName string, podNamespace string
 	}
 
 	netconf, cninet := network.NetworkConfig, network.CNIConfig
-	glog.V(4).Infof("About to run with conf.Network.Type=%v, c.Path=%v", netconf.Network.Type, cninet.Path)
+	glog.V(4).Infof("About to run with conf.Network.Type=%v", netconf.Network.Type)
 	err = cninet.DelNetwork(netconf, rt)
 	if err != nil {
 		glog.Errorf("Error deleting network: %v", err)


### PR DESCRIPTION
This will be needed for rktnetes. I had been testing with an earlier version of the patch and dropped it when building v1.3.2 only to find things broken again.

see: kubernetes#29310
