### PR TITLE
pkg/apiserver/authenticator: move oidc after service accounts

### DIFF
--- a/pkg/apiserver/authenticator/authn.go
+++ b/pkg/apiserver/authenticator/authn.go
@@ -80,20 +80,26 @@ func New(config AuthenticatorConfig) (authenticator.Request, error) {
 		authenticators = append(authenticators, tokenAuth)
 	}
 
-	if len(config.OIDCIssuerURL) > 0 && len(config.OIDCClientID) > 0 {
-		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(config.OIDCIssuerURL, config.OIDCClientID, config.OIDCCAFile, config.OIDCUsernameClaim, config.OIDCGroupsClaim)
-		if err != nil {
-			return nil, err
-		}
-		authenticators = append(authenticators, oidcAuth)
-	}
-
 	if len(config.ServiceAccountKeyFile) > 0 {
 		serviceAccountAuth, err := newServiceAccountAuthenticator(config.ServiceAccountKeyFile, config.ServiceAccountLookup, config.ServiceAccountTokenGetter)
 		if err != nil {
 			return nil, err
 		}
 		authenticators = append(authenticators, serviceAccountAuth)
+	}
+
+	// NOTE(ericchiang): Keep the OpenID Connect after Service Accounts.
+	//
+	// Because both plugins verify JWTs whichever comes first in the union experiences
+	// cache misses for all requests using the other. While the service account plugin
+	// simply returns an error, the OpenID Connect plugin may query the provider to
+	// update the keys, causing performance hits.
+	if len(config.OIDCIssuerURL) > 0 && len(config.OIDCClientID) > 0 {
+		oidcAuth, err := newAuthenticatorFromOIDCIssuerURL(config.OIDCIssuerURL, config.OIDCClientID, config.OIDCCAFile, config.OIDCUsernameClaim, config.OIDCGroupsClaim)
+		if err != nil {
+			return nil, err
+		}
+		authenticators = append(authenticators, oidcAuth)
 	}
 
 	if len(config.KeystoneURL) > 0 {


### PR DESCRIPTION
backports: https://github.com/kubernetes/kubernetes/pull/30457

Both plugins verify JWTs, but the OpenID Connect plugin performs
much worse when faced with cache misses. Reorder the plugins so
the service account plugin tries to authenticate a bearer token
first.
