### PR TITLE
calico: bump to v1.5.6

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -101,7 +101,7 @@ else
 endif
 	# Download CNI
 	curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/cni-${ARCH}-${CNI_RELEASE}.tar.gz | tar -xz -C ${TEMP_DIR}/cni-bin
-	curl -sSL --retry 5 -o  ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.3.1/calico
+	curl -sSL --retry 5 -o  ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.5.6/calico
 	chmod +x ${TEMP_DIR}/cni-bin/bin/calico
 
 	docker build --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}


### PR DESCRIPTION
This fixes issues with calico enablement in https://github.com/coreos-inc/tectonic/pull/1374 that relies on v1.5.5, whereas the hyperkube image shipped in Tectonic is using Calico v1.3.3