### PR TITLE
calico: Bump calico to 1.8.0

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -111,7 +111,7 @@ else
 endif
 	# Download CNI
 	curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/cni-${ARCH}-${CNI_RELEASE}.tar.gz | tar -xz -C ${TEMP_DIR}/cni-bin
-	curl -sSL --retry 5 -o  ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.6.2/calico
+	curl -sSL --retry 5 -o  ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.8.0/calico
 	chmod +x ${TEMP_DIR}/cni-bin/bin/calico
 
 	docker build --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}


### PR DESCRIPTION
Alternative to https://github.com/coreos/kubernetes/pull/130. To be picked up in our next hyperkube release. I believe calico 1.8.0 is needed for k8s 1.6. I'm less clear if CNI needs a bump but we'll have to wait for upstream regardless there I believe.

cc @brianredbeard @aaronlevy 