### PR TITLE
Add CAP_NET_BIND_SERVICE to hyperkube.

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -91,3 +91,6 @@ RUN ln -s /hyperkube /apiserver \
 
 # Copy the hyperkube binary
 COPY hyperkube /hyperkube
+
+# Add CAP_NET_BIND_SERVICE to hyperkube so it can bind privileged ports as non-root.
+RUN setcap cap_net_bind_service=+ep /hyperkube


### PR DESCRIPTION
Add CAP_NET_BIND_SERVICE to hyperkube so it can bind privileged ports as
non-root.