### PR TITLE
Invoke setcap in the Makefile rather than the Dockerfile.

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -91,6 +91,3 @@ RUN ln -s /hyperkube /apiserver \
 
 # Copy the hyperkube binary
 COPY hyperkube /hyperkube
-
-# Add CAP_NET_BIND_SERVICE to hyperkube so it can bind privileged ports as non-root.
-RUN setcap cap_net_bind_service=+ep /hyperkube

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -101,6 +101,8 @@ endif
 ifeq ($(ARCH),amd64)
 	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
 	cd ${TEMP_DIR} && ${SED_CMD} "/CROSS_BUILD_/d" Dockerfile
+	# Add CAP_NET_BIND_SERVICE to hyperkube so it can bind privileged ports as non-root.
+	cd ${TEMP_DIR} && setcap cap_net_bind_service=+ep hyperkube
 else
 	cd ${TEMP_DIR} && ${SED_CMD} "s/CROSS_BUILD_//g" Dockerfile
 


### PR DESCRIPTION
This contains two commits:

(1) Revert the Dockerfile change, since this causes a dramatic increase in the docker image size.
(2) Invoke setcap when hyperkube is built. I verified that this propagates correctly when hyperkube is copied into the docker image.

Fixes #137.