### PR TITLE
coreos-jenkins: commit initial jenkins scripts

### DIFF
--- a/coreos-jenkins/1-hyperkube-release.sh
+++ b/coreos-jenkins/1-hyperkube-release.sh
@@ -1,0 +1,38 @@
+RELEASE_BRANCH="coreos-hyperkube-${RELEASE_TAG}"
+PATCHSET_BRANCH="${RELEASE_TAG}-patchset"
+
+git remote add coreos git@github.com:coreos/kubernetes.git
+
+# Create a release branch from vanilla upstream release tag
+RB_EXISTS=$(GIT_SSH_COMMAND="ssh -i ${DEPLOY_KEY}" git ls-remote coreos ${RELEASE_BRANCH})
+if [ -n "${RB_EXISTS}" ]; then
+    echo "Release branch ${RELEASE_BRANCH} already exists. Skipping"
+else
+	echo "Creating release branch: ${RELEASE_BRANCH}"
+    git checkout ${RELEASE_TAG} -b ${RELEASE_BRANCH}
+    if [ "${DRYRUN}" = false ]; then
+        GIT_SSH_COMMAND="ssh -i ${DEPLOY_KEY}" git push coreos ${RELEASE_BRANCH}
+    fi
+fi
+   
+
+# Create a branch containing previous release patchset
+if [ -n "${PATCHES_FROM}" ]; then
+	GIT_SSH_COMMAND="ssh -i ${DEPLOY_KEY}" git fetch coreos
+    git -c "user.name=Jenkins Deploy" -c "user.email=jenkins@coreos.com" rebase coreos/${RELEASE_BRANCH} coreos/${PATCHES_FROM}
+    git checkout -b ${PATCHSET_BRANCH}
+    if [ "${DRYRUN}" = false ]; then
+        GIT_SSH_COMMAND="ssh -i ${DEPLOY_KEY}" git push coreos ${PATCHSET_BRANCH}
+    fi
+fi
+
+echo
+echo "Release branch: https://github.com/coreos/kubernetes/tree/${RELEASE_BRANCH}"
+if [ -z "${PATCHES_FROM}" ]; then
+    exit 0 # Done.
+fi
+
+echo "Patchset branch: https://github.com/coreos/kubernetes/tree/${PATCHSET_BRANCH}"
+echo 
+echo "Open a pull-request for patchset"
+echo "https://github.com/coreos/kubernetes/compare/${RELEASE_BRANCH}...coreos:${PATCHSET_BRANCH}?expand=1"

--- a/coreos-jenkins/2-hyperkube-release.sh
+++ b/coreos-jenkins/2-hyperkube-release.sh
@@ -1,0 +1,57 @@
+# NOTE(pb): until make release works, containerize make test 
+# and run that then run quick-release
+RKT_OPTS=$(echo \
+  "--volume=k8s,kind=host,source=${PWD} " \
+  "--mount volume=k8s,target=/go/src/k8s.io/kubernetes" \
+  "--volume selinux,kind=host,source=/sys/fs/selinux,readOnly=true" \
+  "--mount volume=selinux,target=/sys/fs/selinux" \
+  "--stage1-from-dir=stage1-fly.aci" )
+
+MAKE_TESTS=$(echo \
+  "cd /go/src/k8s.io/kubernetes &&" \
+  "apt-get update &&" \
+  "apt-get install -y rsync &&" \
+  "make test")
+sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_TESTS}"
+sudo chown -R jenkins:jenkins ./
+
+# make quick-release
+KUBE_RELEASE_RUN_TESTS=n KUBE_FASTBUILD=true build/release.sh
+
+# MAKE TAG DOCKER-SAFE
+IMAGE_TAG=$(echo $RELEASE_TAG | tr + _)
+
+# build hyperkube container
+RKT_OPTS=$(echo \
+  "--volume=k8s,kind=host,source=${PWD} " \
+  "--mount volume=k8s,target=/go/src/k8s.io/kubernetes" \
+  "--volume docker-client,kind=host,source=/usr/bin/docker" \
+  "--mount volume=docker-client,target=/usr/bin/docker" \
+  "--volume=run,kind=host,source=/run" \
+  "--mount volume=run,target=/run" )
+MAKE_KUBE=$(echo \
+  "cd /go/src/k8s.io/kubernetes/cluster/images/hyperkube &&" \
+  "make build REGISTRY=quay.io/coreos VERSION=$IMAGE_TAG")
+sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_KUBE}"
+
+docker tag quay.io/coreos/hyperkube-amd64:$IMAGE_TAG quay.io/coreos/hyperkube:$IMAGE_TAG
+docker images
+
+if [ "$PUSH_IMAGE" = true ] ; then
+	set +x # don't log passwords
+    docker login quay.io --username $DOCKER_USER --password $DOCKER_PASS
+    docker push quay.io/coreos/hyperkube:$IMAGE_TAG
+    wget https://quay.io/c1/aci/quay.io/coreos/hyperkube/$IMAGE_TAG/aci/linux/amd64/ # warm cache before it gets hit in parallel
+fi
+
+# Cleanup
+sudo chown -R jenkins:jenkins ./
+build/make-clean.sh
+
+# all these cleanup commands SHOULD be safe to use if there are other running builds
+sudo rkt gc --grace-period=0s                                          # won't delete running pods
+sudo rkt image gc --grace-period=0s                                    # won't delete image in use by running pods
+docker rm $(docker ps -a -q) || true                                   # delete stopped containeres
+docker rmi $(docker images -q) || true                                 # delete images (fails on images currently used)
+docker volume ls -qf dangling=true | xargs -r docker volume rm || true # delete orphaned volumes 
+

--- a/coreos-jenkins/hyperkube-dev.sh
+++ b/coreos-jenkins/hyperkube-dev.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -e
+
+COMMIT=$(git rev-parse --verify HEAD)
+git tag v9.9.9+coreos.dev.$COMMIT
+
+
+if [ "$BUILD_TYPE" = "binary-only" ] ; then
+  # make all WHAT=cmd/hyperkube in a container
+  RKT_OPTS=$(echo \
+    "--volume=k8s,kind=host,source=${PWD} " \
+    "--mount volume=k8s,target=/go/src/k8s.io/kubernetes")
+
+  MAKE_BIN=$(echo \
+    "cd /go/src/k8s.io/kubernetes &&" \
+    "apt-get update &&" \
+    "apt-get install -y rsync &&" \
+    "KUBE_BUILD_PLATFORMS=linux/amd64 make all WHAT=cmd/hyperkube")
+  sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_BIN}"
+
+  
+  # Copy binary into location expected by hyperkube makefile
+  sudo chown -R jenkins:jenkins ./
+  mkdir -p _output/dockerized/bin/linux/amd64
+  cp _output/local/bin/linux/amd64/hyperkube _output/dockerized/bin/linux/amd64/hyperkube
+  
+elif [ "$BUILD_TYPE" = "quick-release" ] ; then
+  # make quick-release
+  KUBE_RELEASE_RUN_TESTS=n KUBE_FASTBUILD=true build/release.sh
+    
+elif [ "$BUILD_TYPE" = "release" ] ; then
+  # NOTE(pb): until make release works, containerize make test and run that then run quick-release
+  RKT_OPTS=$(echo \
+    "--volume=k8s,kind=host,source=${PWD} " \
+    "--mount volume=k8s,target=/go/src/k8s.io/kubernetes" \
+    "--volume selinux,kind=host,source=/sys/fs/selinux,readOnly=true" \
+    "--mount volume=selinux,target=/sys/fs/selinux" \
+    "--stage1-from-dir=stage1-fly.aci" )
+
+  MAKE_TESTS=$(echo \
+    "cd /go/src/k8s.io/kubernetes &&" \
+    "apt update &&" \
+    "apt install -y rsync &&" \
+    "make test")
+  sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_TESTS}"
+
+  sudo chown -R jenkins:jenkins ./
+
+  # make quick-release
+  KUBE_RELEASE_RUN_TESTS=n KUBE_FASTBUILD=true build/release.sh
+  
+else
+	echo "invalid build type"
+    exit 1
+fi
+
+# build hyperkube container
+RKT_OPTS=$(echo \
+  "--volume=k8s,kind=host,source=${PWD} " \
+  "--mount volume=k8s,target=/go/src/k8s.io/kubernetes" \
+  "--volume docker-client,kind=host,source=/usr/bin/docker" \
+  "--mount volume=docker-client,target=/usr/bin/docker" \
+  "--volume=run,kind=host,source=/run" \
+  "--mount volume=run,target=/run" )
+MAKE_KUBE=$(echo \
+  "cd /go/src/k8s.io/kubernetes/cluster/images/hyperkube &&" \
+  "make build REGISTRY=quay.io/coreos VERSION=$IMAGE_TAG")
+sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_KUBE}"
+
+docker tag quay.io/coreos/hyperkube-amd64:$IMAGE_TAG quay.io/coreos/hyperkube-dev:$IMAGE_TAG
+docker images
+
+if [ "$PUSH_IMAGE" = true ] ; then
+	set +x # don't log passwords
+    docker login --username "$DOCKER_USER" --password "$DOCKER_PASS" quay.io
+    docker push quay.io/coreos/hyperkube-dev:$IMAGE_TAG
+    wget https://quay.io/c1/aci/quay.io/coreos/hyperkube-dev/$IMAGE_TAG/aci/linux/amd64/ # get aci in s3 cache
+fi
+
+# Cleanup
+sudo chown -R jenkins:jenkins ./
+build/make-clean.sh
+
+# all these cleanup commands SHOULD be safe to use if there are other running builds
+sudo rkt gc --grace-period=0s                                          # won't delete running pods
+sudo rkt image gc --grace-period=0s                                    # won't delete image in use by running pods
+docker rm $(docker ps -a -q) || true                                   # delete stopped containeres
+docker rmi $(docker images -q) || true                                 # delete images (fails on images currently used)
+docker volume ls -qf dangling=true | xargs -r docker volume rm || true # delete orphaned volumes 
+

--- a/coreos-jenkins/hyperkube-git-master.sh
+++ b/coreos-jenkins/hyperkube-git-master.sh
@@ -1,0 +1,56 @@
+# make all WHAT=cmd/hyperkube in a container
+RKT_OPTS=$(echo \
+"--volume=k8s,kind=host,source=${PWD} " \
+"--mount volume=k8s,target=/go/src/k8s.io/kubernetes")
+
+MAKE_BIN=$(echo \
+"cd /go/src/k8s.io/kubernetes &&" \
+"apt-get update &&" \
+"apt-get install -y rsync &&" \
+"KUBE_BUILD_PLATFORMS=linux/amd64 make all WHAT=cmd/hyperkube")
+sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_BIN}"
+
+# Copy binary into location expected by hyperkube makefile
+sudo chown -R jenkins:jenkins ./
+mkdir -p _output/dockerized/bin/linux/amd64
+cp _output/local/bin/linux/amd64/hyperkube _output/dockerized/bin/linux/amd64/hyperkube
+
+
+IMAGE_TAG=${GIT_BRANCH}-$(git rev-parse --verify HEAD)
+
+# build hyperkube container
+RKT_OPTS=$(echo \
+  "--volume=k8s,kind=host,source=${PWD} " \
+  "--mount volume=k8s,target=/go/src/k8s.io/kubernetes" \
+  "--volume docker-client,kind=host,source=/usr/bin/docker" \
+  "--mount volume=docker-client,target=/usr/bin/docker" \
+  "--volume=run,kind=host,source=/run" \
+  "--mount volume=run,target=/run" )
+MAKE_KUBE=$(echo \
+  "cd /go/src/k8s.io/kubernetes/cluster/images/hyperkube &&" \
+  "make build REGISTRY=quay.io/coreos VERSION=$IMAGE_TAG")
+sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_KUBE}"
+
+docker tag quay.io/coreos/hyperkube-amd64:${IMAGE_TAG} quay.io/${QUAY_REPO}:${IMAGE_TAG}
+docker tag quay.io/${QUAY_REPO}:${IMAGE_TAG} quay.io/${QUAY_REPO}:${GIT_BRANCH}
+docker images
+
+if [ "$PUSH_IMAGE" = true ] ; then
+	set +x # don't log passwords
+    docker login quay.io --username $DOCKER_USER --password $DOCKER_PASS
+    docker push quay.io/${QUAY_REPO}:${IMAGE_TAG}
+    docker push quay.io/${QUAY_REPO}:${GIT_BRANCH}
+    wget https://quay.io/c1/aci/quay.io/${QUAY_REPO}/${IMAGE_TAG}/aci/linux/amd64/ # get aci in s3 cache
+fi
+
+# Cleanup
+sudo chown -R jenkins:jenkins ./
+build/make-clean.sh
+
+# all these cleanup commands SHOULD be safe to use if there are other running builds
+sudo rkt gc --grace-period=0s                                          # won't delete running pods
+sudo rkt image gc --grace-period=0s                                    # won't delete image in use by running pods
+docker rm $(docker ps -a -q) || true                                   # delete stopped containeres
+docker rmi $(docker images -q) || true                                 # delete images (fails on images currently used)
+docker volume ls -qf dangling=true | xargs -r docker volume rm || true # delete orphaned volumes 
+

--- a/coreos-jenkins/hyperkube-git-release-1.6.sh
+++ b/coreos-jenkins/hyperkube-git-release-1.6.sh
@@ -1,0 +1,56 @@
+# make all WHAT=cmd/hyperkube in a container
+RKT_OPTS=$(echo \
+"--volume=k8s,kind=host,source=${PWD} " \
+"--mount volume=k8s,target=/go/src/k8s.io/kubernetes")
+
+MAKE_BIN=$(echo \
+"cd /go/src/k8s.io/kubernetes &&" \
+"apt-get update &&" \
+"apt-get install -y rsync &&" \
+"KUBE_BUILD_PLATFORMS=linux/amd64 make all WHAT=cmd/hyperkube")
+sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_BIN}"
+
+# Copy binary into location expected by hyperkube makefile
+sudo chown -R jenkins:jenkins ./
+mkdir -p _output/dockerized/bin/linux/amd64
+cp _output/local/bin/linux/amd64/hyperkube _output/dockerized/bin/linux/amd64/hyperkube
+
+
+IMAGE_TAG=${GIT_BRANCH}-$(git rev-parse --verify HEAD)
+
+# build hyperkube container
+RKT_OPTS=$(echo \
+  "--volume=k8s,kind=host,source=${PWD} " \
+  "--mount volume=k8s,target=/go/src/k8s.io/kubernetes" \
+  "--volume docker-client,kind=host,source=/usr/bin/docker" \
+  "--mount volume=docker-client,target=/usr/bin/docker" \
+  "--volume=run,kind=host,source=/run" \
+  "--mount volume=run,target=/run" )
+MAKE_KUBE=$(echo \
+  "cd /go/src/k8s.io/kubernetes/cluster/images/hyperkube &&" \
+  "make build REGISTRY=quay.io/coreos VERSION=$IMAGE_TAG")
+sudo rkt run --insecure-options=image ${RKT_OPTS} docker://golang:${GO_VERSION} --exec /bin/bash -- -c "${MAKE_KUBE}"
+
+docker tag quay.io/coreos/hyperkube-amd64:${IMAGE_TAG} quay.io/${QUAY_REPO}:${IMAGE_TAG}
+docker tag quay.io/${QUAY_REPO}:${IMAGE_TAG} quay.io/${QUAY_REPO}:${GIT_BRANCH}
+docker images
+
+if [ "$PUSH_IMAGE" = true ] ; then
+	set +x # don't log passwords
+    docker login quay.io --username $DOCKER_USER --password $DOCKER_PASS
+    docker push quay.io/${QUAY_REPO}:${IMAGE_TAG}
+    docker push quay.io/${QUAY_REPO}:${GIT_BRANCH}
+    wget https://quay.io/c1/aci/quay.io/${QUAY_REPO}/${IMAGE_TAG}/aci/linux/amd64/ # get aci in s3 cache
+fi
+
+# Cleanup
+sudo chown -R jenkins:jenkins ./
+build/make-clean.sh
+
+# all these cleanup commands SHOULD be safe to use if there are other running builds
+sudo rkt gc --grace-period=0s                                          # won't delete running pods
+sudo rkt image gc --grace-period=0s                                    # won't delete image in use by running pods
+docker rm $(docker ps -a -q) || true                                   # delete stopped containeres
+docker rmi $(docker images -q) || true                                 # delete images (fails on images currently used)
+docker volume ls -qf dangling=true | xargs -r docker volume rm || true # delete orphaned volumes 
+


### PR DESCRIPTION
cc @aaronlevy 

This forms the basis for moving hyperkube build related scripts in-repo that we would then carry as patches along with all our release branches. Notably, this would make the build jobs depend on building a kubernetes branch that carries this commit.

If we move foward with this, we could consolidate alot of this code into common scripts, but, lets figure out if we want this at all first. Alternatively, maybe our team has a separate repo for jenkins scripts (most don't need version control tied to the repo they build).