### PR TITLE
cluster/images/hyperkube: Add the Calico binary

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -14,6 +14,9 @@
 
 FROM BASEIMAGE
 
+# Copy calico to cni bin
+COPY cni-bin/bin/ /opt/cni/bin
+
 # Create symlinks for each hyperkube server
 # Also create symlinks to /usr/local/bin/ where the server image binaries live, so the hyperkube image may be 
 # used instead of gcr.io/google_containers/kube-* without any modifications.

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -26,7 +26,7 @@ TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build
 
-build:
+build: calico
 
 ifndef VERSION
     $(error VERSION is undefined)
@@ -51,4 +51,9 @@ ifeq ($(ARCH),amd64)
 	gcloud docker -- push ${REGISTRY}/hyperkube:${VERSION}
 endif
 
-.PHONY: build push all
+calico:
+	mkdir -p ${TEMP_DIR}/cni-bin/bin
+	curl -sSL --retry 5 -o  ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.10.0/calico
+	chmod +x ${TEMP_DIR}/cni-bin/bin/calico
+
+.PHONY: build push all calico


### PR DESCRIPTION
Carries patches from v01.8.0-beta.0+coreos.0. Tests are passing.

cc @s-urbaniak @aaronlevy 