### PR TITLE
V1.8.3 patchest

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM BASEIMAGE
 
-# Copy calico to cni bin
+# Copy CNI binaries
 COPY cni-bin/bin/ /opt/cni/bin
 
 # Create symlinks for each hyperkube server

--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -14,6 +14,9 @@
 
 FROM BASEIMAGE
 
+# Copy calico to cni bin
+COPY cni-bin/bin/ /opt/cni/bin
+
 # Create symlinks for each hyperkube server
 # Also create symlinks to /usr/local/bin/ where the server image binaries live, so the hyperkube image may be 
 # used instead of gcr.io/google_containers/kube-* without any modifications.

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -20,13 +20,15 @@
 REGISTRY?=gcr.io/google-containers
 ARCH?=amd64
 HYPERKUBE_BIN?=_output/dockerized/bin/linux/$(ARCH)/hyperkube
+CALICO_RELEASE=v1.11.0
+CNI_RELEASE=v0.6.0
 
 BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.4.1
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build
 
-build: calico
+build: cni
 
 ifndef VERSION
     $(error VERSION is undefined)
@@ -51,9 +53,11 @@ ifeq ($(ARCH),amd64)
 	gcloud docker -- push ${REGISTRY}/hyperkube:${VERSION}
 endif
 
-calico:
+cni:
 	mkdir -p ${TEMP_DIR}/cni-bin/bin
-	curl -sSL --retry 5 -o ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.11.0/calico
+	curl -sSL --retry 5 https://github.com/containernetworking/cni/releases/download/${CNI_RELEASE}/cni-${ARCH}-${CNI_RELEASE}.tgz | tar -xz -C ${TEMP_DIR}/cni-bin/bin
+	curl -sSL --retry 5 https://github.com/containernetworking/plugins/releases/download/${CNI_RELEASE}/cni-plugins-${ARCH}-${CNI_RELEASE}.tgz | tar -xz -C ${TEMP_DIR}/cni-bin/bin
+	curl -sSL --retry 5 -o ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/${CALICO_RELEASE}/calico
 	chmod +x ${TEMP_DIR}/cni-bin/bin/calico
 
-.PHONY: build push all calico
+.PHONY: build push all cni

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -53,7 +53,7 @@ endif
 
 calico:
 	mkdir -p ${TEMP_DIR}/cni-bin/bin
-	curl -sSL --retry 5 -o  ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.10.0/calico
+	curl -sSL --retry 5 -o ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.11.0/calico
 	chmod +x ${TEMP_DIR}/cni-bin/bin/calico
 
 .PHONY: build push all calico

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -26,7 +26,7 @@ TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build
 
-build:
+build: calico
 
 ifndef VERSION
     $(error VERSION is undefined)
@@ -51,4 +51,9 @@ ifeq ($(ARCH),amd64)
 	gcloud docker -- push ${REGISTRY}/hyperkube:${VERSION}
 endif
 
-.PHONY: build push all
+calico:
+	mkdir -p ${TEMP_DIR}/cni-bin/bin
+	curl -sSL --retry 5 -o  ${TEMP_DIR}/cni-bin/bin/calico https://github.com/projectcalico/calico-cni/releases/download/v1.10.0/calico
+	chmod +x ${TEMP_DIR}/cni-bin/bin/calico
+
+.PHONY: build push all calico


### PR DESCRIPTION
This PR carries all the patches from 1.8.2 excluding the modprobe patch, since that made it into the upstream released.

cc @aaronlevy @s-urbaniak 