### PR TITLE
version: fix regex to pull minor and major versions

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -89,12 +89,9 @@ kube::version::get_version_vars() {
       # Try to match the "git describe" output to a regex to try to extract
       # the "major" and "minor" versions and whether this is the exact tagged
       # version or whether the tree is between two tagged versions.
-      if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?$ ]]; then
+      if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-+].*)?$ ]]; then
         KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
         KUBE_GIT_MINOR=${BASH_REMATCH[2]}
-        if [[ -n "${BASH_REMATCH[4]}" ]]; then
-          KUBE_GIT_MINOR+="+"
-        fi
       fi
     fi
   fi


### PR DESCRIPTION
gitMajor and gitMinor are being deprecated, but this patch preserves the major and minor version by tweaking the regex when building k8s.

Our version string never parsed correctly with the included +: `v1.9.0+coreos.0`...