### PR TITLE
device registration race fix

### DIFF
--- a/pkg/kubelet/deviceplugin/manager_test.go
+++ b/pkg/kubelet/deviceplugin/manager_test.go
@@ -70,6 +70,13 @@ func TestDevicePluginReRegistration(t *testing.T) {
 	p1.Register(socketName, testResourceName)
 	// Wait for the first callback to be issued.
 	<-callbackChan
+	// Wait till the endpoint is added to the manager.
+	for i := 0; i < 20; i++ {
+		if len(m.Devices()) > 0 {
+			break
+		}
+		time.Sleep(1)
+	}
 	devices := m.Devices()
 	require.Equal(t, 2, len(devices[testResourceName]), "Devices are not updated.")
 

--- a/pkg/kubelet/deviceplugin/manager_test.go
+++ b/pkg/kubelet/deviceplugin/manager_test.go
@@ -75,7 +75,7 @@ func TestDevicePluginReRegistration(t *testing.T) {
 		if len(m.Devices()) > 0 {
 			break
 		}
-		time.Sleep(1)
+		time.Sleep(1 * time.Second)
 	}
 	devices := m.Devices()
 	require.Equal(t, 2, len(devices[testResourceName]), "Devices are not updated.")


### PR DESCRIPTION
Upstream PR: https://github.com/kubernetes/kubernetes/pull/53028

@xiang90 noticed it uses a nanosecond timeout, so I fixed that in a subsequent patch.